### PR TITLE
Adding example for customizing the App Distro iOS SDK

### DIFF
--- a/start/AppDistributionExample/AppDelegate.swift
+++ b/start/AppDistributionExample/AppDelegate.swift
@@ -20,6 +20,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication,
                    didFinishLaunchingWithOptions launchOptions: [UIApplication
                      .LaunchOptionsKey: Any]?) -> Bool {
+    
+    FirebaseApp.configure()
     return true
   }
 

--- a/start/AppDistributionExample/AppDistributionViewController.swift
+++ b/start/AppDistributionExample/AppDistributionViewController.swift
@@ -13,19 +13,127 @@
 // limitations under the License.
 
 import UIKit
+import Firebase
 
 class AppDistributionViewController: UIViewController {
+    var checkForUpdateButton: UIButton?
+    var signInOutButton: UIButton?
+    var signedInStatus: UILabel?
+    var currentVersion: UILabel?
+    let primaryButtonColor: UIColor = .init(red: 0.10, green: 0.44, blue: 0.91, alpha: 1)
+    let secondaryButtonColor: UIColor = .init(red: 0.40, green: 0.23, blue: 0.71, alpha: 1)
 
   override func viewDidLoad() {
     super.viewDidLoad()
     configureNavigationBar()
+    
+    currentVersion = UILabel(frame: CGRect(x: 50, y: 150, width: 400, height: 50))
+    let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")
+    let build = Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String)
+    currentVersion!.text = "App Info: Version - \(version ?? ""), Build - \(build ?? "")"
+    currentVersion!.textColor = .orange
+    currentVersion!.font = .systemFont(ofSize: 18.0)
+    view.addSubview(currentVersion!)
+    
+    // Show check for update button only if tester is signed in
+    checkForUpdateButton = UIButton(frame: CGRect(x: 50, y: 300, width: 300, height: 50))
+    configureCheckForUpdateButton()
+    view.addSubview(checkForUpdateButton!)
+
+    // Toggle sign in and sign out based on whether tester is signed in
+    signInOutButton = UIButton(frame: CGRect(x: 50, y: 400, width: 300, height: 50))
+    configureSignInSignOutButton()
+    signInOutButton!.addTarget(self, action: #selector(signInOutButtonClicked), for: .touchUpInside)
+    view.addSubview(signInOutButton!)
+    
+    // Toggle sign in status based on whether tester is signed in or nor
+    signedInStatus = UILabel(frame: CGRect(x: 120, y: 500, width: 400, height: 50))
+    configureSignInStatus()
+    view.addSubview(signedInStatus!)
   }
 
-  // MARK: - Firebase 🔥
+    // MARK: - Firebase 🔥
   override func viewDidAppear(_ animated: Bool) {
   }
   // MARK: - Private Helpers
 
+    @objc func checkForUpdateButtonClicked() {
+        AppDistribution.appDistribution().checkForUpdate(completion: { [self] release, error in
+            var uiAlert: UIAlertController
+
+            if error != nil {
+                uiAlert = UIAlertController(title: "Error", message: "Error Checking for update! \(error?.localizedDescription ?? "")", preferredStyle: .alert)
+            } else if release == nil {
+                uiAlert = UIAlertController(title: "Check for Update", message: "No releases found!!", preferredStyle: .alert)
+                uiAlert.addAction(UIAlertAction(title: "Ok", style: UIAlertAction.Style.default))
+            } else {
+                guard let release = release else { return }
+
+                let title = "New Version Available"
+                let message = "Version \(release.displayVersion)(\(release.buildVersion)) is available."
+                uiAlert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+
+                uiAlert.addAction(UIAlertAction(title: "Update", style: UIAlertAction.Style.default) {
+                    _ in
+                    UIApplication.shared.open(release.downloadURL)
+                })
+                uiAlert.addAction(UIAlertAction(title: "Cancel", style: UIAlertAction.Style.cancel) {
+                    _ in
+                })
+            }
+
+            self.present(uiAlert, animated: true, completion: nil)
+        })
+    }
+    
+    @objc func signInOutButtonClicked() {
+        if AppDistribution.appDistribution().isTesterSignedIn {
+            AppDistribution.appDistribution().signOutTester()
+            
+            self.configureCheckForUpdateButton()
+            self.configureSignInSignOutButton()
+            self.configureSignInStatus()
+            
+        } else {
+            AppDistribution.appDistribution().signInTester(completion: { error in
+                if error == nil {
+                    self.configureCheckForUpdateButton()
+                    self.configureSignInSignOutButton()
+                    self.configureSignInStatus()
+                } else {
+                    let uiAlert = UIAlertController(title: "Custom:Error", message: "Error during tester sign in! \(error?.localizedDescription ?? "")", preferredStyle: .alert)
+                    uiAlert.addAction(UIAlertAction(title: "Ok", style: UIAlertAction.Style.default) {
+                        _ in
+                    })
+
+                    self.present(uiAlert, animated: true, completion: nil)
+                }
+            })
+        }
+    }
+    
+    private func configureCheckForUpdateButton() {
+        checkForUpdateButton!.backgroundColor = primaryButtonColor
+        checkForUpdateButton!.setTitle("Check for Update Manually", for: .normal)
+        checkForUpdateButton!.addTarget(self, action: #selector(checkForUpdateButtonClicked), for: .touchUpInside)
+        checkForUpdateButton!.isHidden = !AppDistribution.appDistribution().isTesterSignedIn
+    }
+    
+    private func configureSignInSignOutButton() {
+        signInOutButton!.backgroundColor = AppDistribution.appDistribution().isTesterSignedIn ? secondaryButtonColor : primaryButtonColor
+        signInOutButton!.setTitleColor(.white, for: .normal)
+        let title = AppDistribution.appDistribution().isTesterSignedIn ? "Sign Out" : "Sign In"
+        signInOutButton!.setTitle(title, for: .normal)
+        signInOutButton!.setTitleColor(.white, for: .normal)
+        signInOutButton!.isHidden = false
+    }
+    
+    private func configureSignInStatus() {
+        signedInStatus!.textColor = AppDistribution.appDistribution().isTesterSignedIn ? .green : .orange
+        signedInStatus!.font = .boldSystemFont(ofSize: 20.0)
+        signedInStatus!.text = AppDistribution.appDistribution().isTesterSignedIn ? "Tester is signed in" : "Tester is signed out"
+    }
+    
   private func configureNavigationBar() {
     navigationItem.title = "Firebase App Distribution"
     guard let navigationBar = navigationController?.navigationBar else { return }


### PR DESCRIPTION
- Adding UI buttons and labels to demonstrate App Distro iOS SDK customization.
- Added a button that would either sign in or sign out a tester based on their sign in status. 
- Added a label that indicates the testers sign in status
- Added a "check for update" button that checks for new builds. But its only visible if tester is signed in

![image](https://user-images.githubusercontent.com/1452276/115407049-b86d6500-a1bd-11eb-9123-58f2c2586c0d.png)
![image](https://user-images.githubusercontent.com/1452276/115407071-bd321900-a1bd-11eb-93bc-f8054fb365f0.png)
